### PR TITLE
📝 docs: Added setup steps for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@
 	- URL de la foto
 - images:
 	- Array de ids de las imágenes subidas por el usuario
+
+## Setup
+- `npm install`
+- `npm run docker:up`
+- `npm run dev`
+
+
+### Apple Silicon chips
+La imagen de docker de mongodb oficial no es soportada todavía con docker. Los workarounds son cualquiera de los siguientes:
+1. Cambiar la imagen en docker-compose por una no oficial creada por la comunidad -> [referencia](https://github.com/ZCube/bitnami-compat)
+2. Instalar mongodb x86_64 en tu local emulando con Rosetta -> [referencia](https://www.mongodb.com/community/forums/t/mongo-5-on-apple-m1-laptops-via-docker/136506/7)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   mongodb:
     container_name: mongodb_dev
     image: docker.io/bitnami/mongodb:latest
+    # image: ghcr.io/zcube/bitnami-compat/mongodb:5.0.9 # Unofficial workaround for Apple Silicon chips, don't use it in prod
     restart: always
     environment:
       MONGODB_ADVERTISED_HOSTNAME: ${MONGODB_HOSTNAME:-localhost}


### PR DESCRIPTION
I was setting the project up after watching the VOD of last streaming, but mongodb official docker images don't support Apple Silicon chips yet.

 I left it commented as the current solution works for windows or Apple intel users. Also small disclaimer with that docker image: `It's not properly tested and maintained, do NOT use in prod`

Hope it helps others and Pablo has a bit of fun with us poor Apple users 😉

Let me know any other change/addition on this one, I'd be happy to help